### PR TITLE
fix(stats): :speech_balloon: school scoreboard now incldues school na…

### DIFF
--- a/src/components/stats/schoolWideScoreboard.tsx
+++ b/src/components/stats/schoolWideScoreboard.tsx
@@ -13,12 +13,11 @@ import {
   UserSummary,
 } from "@/services/types/summary";
 import Scoreboard from "@/src/components/stats/genericScoreboard";
+import { useThemedStyles } from "@/src/hooks/useStyleSheet";
 import axios, { isAxiosError } from "axios";
 import { useEffect, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import { BaseStyles } from "../../constants/Styles";
-import { useThemedStyles } from "@/src/hooks/useStyleSheet";
-import { ThemeContext } from "@react-navigation/native";
 
 /**
  * School-wide scoreboard that lists all classes in the user's school.
@@ -32,6 +31,7 @@ export default function SchoolScoreboard() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [userClass, setUserClass] = useState<string | null>(null);
+  const [schoolName, setSchoolName] = useState<string | null>(null);
   const themedStyles = useThemedStyles();
 
   const getBackendErrorMessage = (data: unknown): string => {
@@ -60,6 +60,7 @@ export default function SchoolScoreboard() {
 
         const summary = response.data;
         setUserClass(summary.className);
+        setSchoolName(summary.schoolName);
         if (!summary.schoolName) {
           setError("User is not registered to a school");
           return null;
@@ -205,6 +206,7 @@ export default function SchoolScoreboard() {
         points={points}
         isLoading={isLoading}
         highlightedEntity={userClass ?? undefined}
+        titleOverride={schoolName ?? undefined}
       />
     </View>
   );


### PR DESCRIPTION
…me in header

# Pull Request

## Summary

School wide scoreboard now includes school name in scoreboard header

---

## Changes Made

- Feature 1: see summary

---

## Screenshots / Visual Changes

<!-- Upload images by dragging & dropping or using Markdown image syntax -->

| Before | After |
|--------|-------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/43e97c2b-e4e6-4864-ba34-21c427ce2c2f" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e0b5c08a-4fcb-4e1e-9b41-4df0d78ffa39" /> |

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code where necessary
- [ ] I have added tests or updated existing ones
- [x] My changes generate no new warnings
- [x] I have attached relevant screenshots (if UI-related)
